### PR TITLE
feat: Define content type

### DIFF
--- a/pages/api/upload-url.js
+++ b/pages/api/upload-url.js
@@ -13,6 +13,7 @@ export default async function handler(req, res) {
     Bucket: process.env.BUCKET_NAME,
     Fields: {
       key: req.query.file,
+      "Content-Type": req.query.fileType
     },
     Expires: 60, // seconds
     Conditions: [

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,7 +2,8 @@ export default function Upload() {
   const uploadPhoto = async (e) => {
     const file = e.target.files[0];
     const filename = encodeURIComponent(file.name);
-    const res = await fetch(`/api/upload-url?file=${filename}`);
+    const fileType = encodeURIComponent(file.type);
+    const res = await fetch(`/api/upload-url?file=${filename}&fileType=${fileType}`);
     const { url, fields } = await res.json();
     const formData = new FormData();
 


### PR DESCRIPTION
Related to #1

The current example uploads all files as `binary/octet-stream` and it can't be interpretable by `Image` next.js component for example. And I'm sure it causes all sorts of other issues.
This PR fixes this by declaring the `Content-Type` of the uploading file in the presigned URL